### PR TITLE
feat(profiles): add single_stream profile family

### DIFF
--- a/ai_energy_benchmarks/profiles/definitions.py
+++ b/ai_energy_benchmarks/profiles/definitions.py
@@ -222,6 +222,50 @@ def get_long_tokens_profile() -> LoadProfileConfig:
     )
 
 
+# Single-stream profiles - concurrency=1, one request at a time. Designed to
+# match the methodology of public intelligence benchmarks (e.g. Artificial
+# Analysis) that issue prompts serially without batching. Useful as a clean
+# per-request energy baseline that is comparable across hardware without
+# concurrency confounding the measurement.
+def get_single_stream_light_profile() -> LoadProfileConfig:
+    """Get the single-stream light profile (concurrency=1, short outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_light",
+        description="Single-stream light - concurrency=1, short outputs (~100-200 tokens)",
+        concurrency=1,
+        request_count=30,
+        input_token_range=(50, 150),
+        output_token_range=(100, 200),
+        cache_strategy="minimal",
+    )
+
+
+def get_single_stream_moderate_profile() -> LoadProfileConfig:
+    """Get the single-stream moderate profile (concurrency=1, medium outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_moderate",
+        description="Single-stream moderate - concurrency=1, medium outputs (~200-500 tokens)",
+        concurrency=1,
+        request_count=30,
+        input_token_range=(50, 150),
+        output_token_range=(200, 500),
+        cache_strategy="minimal",
+    )
+
+
+def get_single_stream_heavy_profile() -> LoadProfileConfig:
+    """Get the single-stream heavy profile (concurrency=1, long outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_heavy",
+        description="Single-stream heavy - concurrency=1, long outputs (~500-1000 tokens)",
+        concurrency=1,
+        request_count=20,
+        input_token_range=(50, 150),
+        output_token_range=(500, 1000),
+        cache_strategy="minimal",
+    )
+
+
 # Profile registry - lazy initialized and cached
 _PROFILES_CACHE: Optional[Dict[str, Union[LoadProfileConfig, MultiPhaseProfile]]] = None
 
@@ -246,6 +290,10 @@ def _get_profiles_registry() -> MappingProxyType:
             "short_tokens": get_short_tokens_profile(),
             "long_input_short_output": get_long_input_short_output_profile(),
             "long_tokens": get_long_tokens_profile(),
+            # Single-stream profiles (concurrency=1, AA-comparable)
+            "single_stream_light": get_single_stream_light_profile(),
+            "single_stream_moderate": get_single_stream_moderate_profile(),
+            "single_stream_heavy": get_single_stream_heavy_profile(),
         }
     return MappingProxyType(_PROFILES_CACHE)
 
@@ -254,7 +302,9 @@ def get_profile(name: str) -> Union[LoadProfileConfig, MultiPhaseProfile]:
     """Get a profile by name.
 
     Args:
-        name: Profile name (light, moderate, heavy, stress, multiphase, pattern, power_test)
+        name: Profile name (light, moderate, heavy, stress, multiphase, pattern,
+            power_test, short_tokens, long_input_short_output, long_tokens,
+            single_stream_light, single_stream_moderate, single_stream_heavy)
 
     Returns:
         LoadProfileConfig or MultiPhaseProfile
@@ -310,5 +360,8 @@ __all__ = [
     "get_short_tokens_profile",
     "get_long_input_short_output_profile",
     "get_long_tokens_profile",
+    "get_single_stream_light_profile",
+    "get_single_stream_moderate_profile",
+    "get_single_stream_heavy_profile",
     "PROFILES",
 ]

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -15,6 +15,9 @@ from ai_energy_benchmarks.profiles.definitions import (
     get_power_test_profile,
     get_profile,
     get_short_tokens_profile,
+    get_single_stream_heavy_profile,
+    get_single_stream_light_profile,
+    get_single_stream_moderate_profile,
     get_stress_profile,
     is_multi_phase,
     list_profiles,
@@ -237,6 +240,36 @@ class TestProfileDefinitions:
         assert profile.input_token_range == (1000, 2000)
         assert profile.output_token_range == (1000, 2000)
 
+    def test_get_single_stream_light_profile(self):
+        """Test single_stream_light profile definition."""
+        profile = get_single_stream_light_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_light"
+        assert profile.concurrency == 1
+        assert profile.request_count == 30
+        assert profile.output_token_range == (100, 200)
+
+    def test_get_single_stream_moderate_profile(self):
+        """Test single_stream_moderate profile definition."""
+        profile = get_single_stream_moderate_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_moderate"
+        assert profile.concurrency == 1
+        assert profile.request_count == 30
+        assert profile.output_token_range == (200, 500)
+
+    def test_get_single_stream_heavy_profile(self):
+        """Test single_stream_heavy profile definition."""
+        profile = get_single_stream_heavy_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_heavy"
+        assert profile.concurrency == 1
+        assert profile.request_count == 20
+        assert profile.output_token_range == (500, 1000)
+
 
 class TestProfileRegistry:
     """Tests for profile registry functions."""
@@ -257,7 +290,11 @@ class TestProfileRegistry:
         assert "short_tokens" in profiles
         assert "long_input_short_output" in profiles
         assert "long_tokens" in profiles
-        assert len(profiles) == 10
+        # Single-stream profiles
+        assert "single_stream_light" in profiles
+        assert "single_stream_moderate" in profiles
+        assert "single_stream_heavy" in profiles
+        assert len(profiles) == 13
 
     def test_get_profile_valid(self):
         """Test get_profile returns correct profile for valid names."""
@@ -283,6 +320,10 @@ class TestProfileRegistry:
         assert is_multi_phase(get_short_tokens_profile()) is False
         assert is_multi_phase(get_long_input_short_output_profile()) is False
         assert is_multi_phase(get_long_tokens_profile()) is False
+        # Single-stream profiles are also single-phase
+        assert is_multi_phase(get_single_stream_light_profile()) is False
+        assert is_multi_phase(get_single_stream_moderate_profile()) is False
+        assert is_multi_phase(get_single_stream_heavy_profile()) is False
 
     def test_is_multi_phase_multi(self):
         """Test is_multi_phase returns True for multi-phase profiles."""
@@ -293,7 +334,7 @@ class TestProfileRegistry:
     def test_profiles_registry_populated(self):
         """Test profiles registry is populated correctly."""
         profiles = _get_profiles_registry()
-        assert len(profiles) == 10
+        assert len(profiles) == 13
         assert all(name in profiles for name in list_profiles())
 
 
@@ -335,6 +376,9 @@ class TestProfileConsistency:
             "short_tokens",
             "long_input_short_output",
             "long_tokens",
+            "single_stream_light",
+            "single_stream_moderate",
+            "single_stream_heavy",
         ]
         for name in single_phase_profiles:
             profile = get_profile(name)


### PR DESCRIPTION
## Summary

Adds three `concurrency=1` profiles (`single_stream_light`, `single_stream_moderate`, `single_stream_heavy`) so callers can produce energy numbers comparable to single-stream public intelligence benchmarks (Artificial Analysis, HF AIEnergyScore) without hand-rolling their own `LoadProfileConfig`.

## Motivation

We maintain a downstream sweep harness in `neuralwatt/energy-aware-inference` whose only meaningful divergence from `ai_energy_benchmarks` is `concurrency=1`. That mismatch is the entire reason a parallel harness exists. Adding the single-stream shape upstream lets the downstream consumer go back to using the library directly, which is the whole point of publishing it.

Token ranges mirror the existing light/moderate/heavy convention so existing per-request sweeps move over without changing workload shape — only the concurrency.

## Test plan

- [x] `pytest tests/unit/test_profiles.py` — 47 passed, 100% line coverage on `profiles/definitions.py`
- [x] `pytest tests/unit/` — 163 passed (no regression elsewhere)
- [x] New tests cover each profile definition, registry inclusion, single-phase classification, and token-range validity

---

Downstream consumer that will use these: `neuralwatt/energy-aware-inference` `scripts/sweep_codecarbon.py` (rewrite in flight as a thin `gpuctl` orchestrator over `ai-energy-profile`).