### PR TITLE
feat(executors): add SingleStreamExecutor for on-box per-request energy

### DIFF
--- a/ai_energy_benchmarks/backends/vllm.py
+++ b/ai_energy_benchmarks/backends/vllm.py
@@ -171,7 +171,7 @@ class VLLMBackend(Backend):
             formatted_prompt = self.format_harmony_prompt(prompt, reasoning_effort)
             print(f"  Using Harmony format with {reasoning_effort} reasoning")
 
-        payload = {
+        payload: Dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": formatted_prompt}],
             "max_tokens": max_tokens,

--- a/ai_energy_benchmarks/cli/single_stream.py
+++ b/ai_energy_benchmarks/cli/single_stream.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""CLI entry point for single-stream on-box energy benchmarks.
+
+Runs prompts one at a time against a local vLLM (or other OpenAI-compatible)
+endpoint, samples GPU power locally during each request, and emits one
+JSONL row per request with energy / token / timing metrics.
+
+This is the on-box equivalent of `ai-energy-profile`, but for energy
+measurement instead of load testing. Use this against raw vLLM where
+the response doesn't include an `energy` field. Use `EnergyAwareExecutor`
+(via library API, not CLI yet) against the NW gateway where it does.
+
+Output format: a JSONL file with a `_meta` header row followed by one
+row per request. The schema matches what downstream consumers in the
+`energy-aware-inference` repo expect, so the file can be loaded directly
+by their `frontier dataset build` pipeline.
+"""
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..executors.single_stream import (
+    DEFAULT_POWER_SAMPLE_INTERVAL_S,
+    SingleStreamExecutor,
+)
+from ..profiles import LoadProfileConfig
+from ..profiles.definitions import get_profile, is_multi_phase
+
+SINGLE_STREAM_PROFILES = ["single_stream_light", "single_stream_moderate", "single_stream_heavy"]
+
+
+def detect_gpu_type() -> str:
+    """Return normalized GPU model (e.g. 'A100', 'H200') from nvidia-smi."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            raw = result.stdout.strip().split("\n")[0]
+            return raw.replace("NVIDIA ", "").replace("-", " ")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def detect_gpu_count() -> int:
+    """Return the number of visible NVIDIA GPUs (0 if nvidia-smi unavailable)."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=count", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            # nvidia-smi prints the count for every GPU (one line each); take any
+            return int(result.stdout.strip().split("\n")[0])
+    except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
+        pass
+    return 0
+
+
+def build_meta_header(
+    model: str,
+    profile_name: str,
+    args: argparse.Namespace,
+) -> Dict[str, Any]:
+    """Build the `_meta` JSONL header row.
+
+    Shape matches what downstream `energy-aware-inference` expects so the
+    file can be consumed by their loader without translation. The
+    `benchmark_source` field is set to `"codecarbon_sweep"` for backwards
+    compatibility with their tagging, even though we no longer use the
+    CodeCarbon library here — `codecarbon_sweep` historically meant
+    "on-box single-stream power-sampling," which is exactly what this CLI
+    does.
+    """
+    gpu_count = args.tensor_parallel
+    meta: Dict[str, Any] = {
+        "_meta": True,
+        "model": model,
+        "gpu_type": args.gpu_type or detect_gpu_type(),
+        "profile_name": profile_name.replace("single_stream_", ""),
+        "gpu_count": gpu_count,
+        "tensor_parallel": args.tensor_parallel,
+        "concurrency": 1,
+        "serving_engine": args.serving_engine,
+        "benchmark_source": "codecarbon_sweep",
+        "measurement_mode": "local-power-sampling",
+        "energy_collector": "nvidia-smi",
+        "power_sample_interval_s": args.power_sample_interval,
+        "serving_host": args.endpoint,
+        "benchmark_host": os.environ.get("HOSTNAME", platform.node() or "unknown"),
+    }
+    if args.quantization:
+        meta["quantization"] = args.quantization
+    if args.max_model_len:
+        meta["max_model_len"] = args.max_model_len
+    if args.gpu_memory_utilization is not None:
+        meta["gpu_memory_utilization"] = args.gpu_memory_utilization
+    return meta
+
+
+def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
+    """Convert a RequestResult to the JSONL row shape downstream expects."""
+    if req.error is not None:
+        return {
+            "error": req.error,
+            "duration_seconds": round(req.request_duration_seconds, 4),
+            "estimated": False,
+        }
+    energy_j = req.energy_joules or 0.0
+    output_tokens = req.completion_tokens or 0
+    total_tokens = req.total_tokens or 0
+    row: Dict[str, Any] = {
+        "energy_joules": round(energy_j, 4),
+        "avg_power_watts": round(req.avg_power_watts or 0.0, 1),
+        "duration_seconds": round(req.request_duration_seconds, 4),
+        "input_tokens": req.prompt_tokens,
+        "output_tokens": output_tokens,
+        "thinking_tokens": 0,
+        "estimated": False,
+        "tokens_per_joule": round(total_tokens / energy_j, 4) if energy_j > 0 else 0,
+        "energy_per_useful_token": round(energy_j / output_tokens, 4) if output_tokens > 0 else 0,
+    }
+    return row
+
+
+def write_jsonl_output(
+    output_path: Path,
+    meta: Dict[str, Any],
+    results: List[Any],
+) -> None:
+    """Write the meta header + per-request rows to JSONL."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        f.write(json.dumps(meta) + "\n")
+        for r in results:
+            f.write(json.dumps(request_result_to_jsonl_row(r)) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run a single-stream on-box energy benchmark against a vLLM endpoint",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Default single_stream_light profile against local vLLM
+  ai-energy-single-stream --model Qwen/Qwen3-32B
+
+  # Heavy profile against a remote vLLM, save output to a specific dir
+  ai-energy-single-stream --model Qwen/Qwen3-32B \\
+    --endpoint http://10.0.0.5:8000/v1 \\
+    --profile single_stream_heavy \\
+    --output-dir ./results
+
+  # Reproducible run with explicit seed and TP=2
+  ai-energy-single-stream --model meta-llama/Llama-3.3-70B \\
+    --profile single_stream_moderate \\
+    --tensor-parallel 2 --seed 42
+
+Profiles available (single-stream only — concurrency is always 1 here):
+  single_stream_light     - 30 requests, 100-200 output tokens
+  single_stream_moderate  - 30 requests, 200-500 output tokens
+  single_stream_heavy     - 20 requests, 500-1000 output tokens
+        """,
+    )
+
+    parser.add_argument(
+        "--profile",
+        choices=SINGLE_STREAM_PROFILES,
+        default="single_stream_light",
+        help="Single-stream profile to use (default: single_stream_light)",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="http://localhost:8000/v1",
+        help="OpenAI-compatible endpoint URL (default: http://localhost:8000/v1)",
+    )
+    parser.add_argument("--model", required=True, help="Model name (required)")
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Optional bearer token (omit for unauthenticated local vLLM)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./single_stream_results",
+        help="Directory for JSONL output (default: ./single_stream_results)",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=None,
+        help="Override output filename; default is <model>_<profile>_<timestamp>.jsonl",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=120,
+        help="Per-request HTTP timeout in seconds (default: 120)",
+    )
+    parser.add_argument(
+        "--power-sample-interval",
+        type=float,
+        default=DEFAULT_POWER_SAMPLE_INTERVAL_S,
+        help=f"GPU power sample interval in seconds (default: {DEFAULT_POWER_SAMPLE_INTERVAL_S})",
+    )
+    parser.add_argument(
+        "--tensor-parallel",
+        type=int,
+        default=1,
+        help="Tensor parallelism — only metadata, doesn't change measurement (default: 1)",
+    )
+    parser.add_argument(
+        "--serving-engine",
+        default="vllm",
+        help="Serving engine label for metadata (default: vllm)",
+    )
+    parser.add_argument("--gpu-type", default=None, help="Override detected GPU type label")
+    parser.add_argument("--quantization", default=None, help="Quantization label for metadata")
+    parser.add_argument("--max-model-len", type=int, default=None, help="Metadata only")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=None, help="Metadata only")
+
+    args = parser.parse_args()
+
+    profile = get_profile(args.profile)
+    if is_multi_phase(profile):
+        print(f"Profile '{args.profile}' is multi-phase; single-stream requires single-phase.")
+        sys.exit(2)
+    assert isinstance(profile, LoadProfileConfig)
+
+    print("Single-stream benchmark")
+    print(f"  profile:  {args.profile}")
+    print(f"  endpoint: {args.endpoint}")
+    print(f"  model:    {args.model}")
+    print(f"  requests: {profile.request_count}")
+    print(f"  out_tok:  {profile.output_token_range}")
+    print(f"  seed:     {args.seed}")
+    print("=" * 60)
+
+    executor = SingleStreamExecutor(
+        seed=args.seed, power_sample_interval_s=args.power_sample_interval
+    )
+    result = executor.run(
+        profile=profile,
+        endpoint=args.endpoint,
+        model=args.model,
+        api_key=args.api_key,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+    if args.output_file:
+        output_path = Path(args.output_dir) / args.output_file
+    else:
+        safe_model = args.model.replace("/", "_").replace("\\", "_")
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        short_profile = args.profile.replace("single_stream_", "")
+        output_path = Path(args.output_dir) / f"{safe_model}_{short_profile}_{timestamp}.jsonl"
+
+    meta = build_meta_header(args.model, args.profile, args)
+    write_jsonl_output(output_path, meta, result.individual_results)
+
+    print(f"\nSaved {result.successful_requests} measurements → {output_path}")
+    print(f"  failed: {result.failed_requests}")
+    if result.energy_available:
+        print(f"  total energy: {result.total_energy_joules:.1f} J")
+        print(f"  avg power:    {result.avg_power_watts:.1f} W")
+        print(f"  tok/J:        {result.tokens_per_joule:.3f}")
+
+    sys.exit(0 if result.successful_requests > 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_energy_benchmarks/cli/single_stream.py
+++ b/ai_energy_benchmarks/cli/single_stream.py
@@ -75,6 +75,7 @@ def build_meta_header(
     model: str,
     profile_name: str,
     args: argparse.Namespace,
+    serving_host: str | None = None,
 ) -> Dict[str, Any]:
     """Build the `_meta` JSONL header row.
 
@@ -100,7 +101,12 @@ def build_meta_header(
         "measurement_mode": "local-power-sampling",
         "energy_collector": "nvidia-smi",
         "power_sample_interval_s": args.power_sample_interval,
-        "serving_host": args.endpoint,
+        # Prefer the normalized endpoint returned by the executor — it has
+        # been canonicalized (rstrip("/"), `/v1` appended if missing), so
+        # the meta matches what was actually hit. Falls back to the raw
+        # argparse value when the caller didn't pass an executor result
+        # (e.g. test scenarios building a header in isolation).
+        "serving_host": serving_host if serving_host is not None else args.endpoint,
         "benchmark_host": os.environ.get("HOSTNAME", platform.node() or "unknown"),
     }
     if args.quantization:
@@ -122,6 +128,12 @@ def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
         }
         if req.sample_errors is not None:
             row_err["sample_errors"] = req.sample_errors
+        # Surface the numeric HTTP status so downstream consumers can
+        # group/filter without regex-parsing the stringified error message.
+        # status_code is only set on the HTTPError path; transport-level
+        # failures (URLError, connection refused) leave it as None.
+        if req.status_code is not None:
+            row_err["status_code"] = req.status_code
         return row_err
     output_tokens = req.completion_tokens or 0
     total_tokens = req.total_tokens or 0
@@ -138,9 +150,16 @@ def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
         energy_j = req.energy_joules
         row["energy_joules"] = round(energy_j, 4)
         row["avg_power_watts"] = round(req.avg_power_watts or 0.0, 1)
-        row["tokens_per_joule"] = round(total_tokens / energy_j, 4) if energy_j > 0 else 0
+        # tokens_per_joule and energy_per_useful_token are mathematically
+        # undefined when their denominator is 0 (no tokens generated, or no
+        # energy sampled). Emit `None` rather than `0` so downstream avg
+        # computations can skip them — averaging 0s would drag the metric
+        # toward zero and mask a measurement failure.
+        row["tokens_per_joule"] = (
+            round(total_tokens / energy_j, 4) if energy_j > 0 and total_tokens > 0 else None
+        )
         row["energy_per_useful_token"] = (
-            round(energy_j / output_tokens, 4) if output_tokens > 0 else 0
+            round(energy_j / output_tokens, 4) if output_tokens > 0 else None
         )
     else:
         row["energy_joules"] = None
@@ -287,7 +306,7 @@ Profiles available (single-stream only — concurrency is always 1 here):
         short_profile = args.profile.replace("single_stream_", "")
         output_path = Path(args.output_dir) / f"{safe_model}_{short_profile}_{timestamp}.jsonl"
 
-    meta = build_meta_header(args.model, args.profile, args)
+    meta = build_meta_header(args.model, args.profile, args, serving_host=result.endpoint)
     write_jsonl_output(output_path, meta, result.individual_results)
 
     print(f"\nSaved {result.successful_requests} measurements → {output_path}")

--- a/ai_energy_benchmarks/cli/single_stream.py
+++ b/ai_energy_benchmarks/cli/single_stream.py
@@ -53,23 +53,6 @@ def detect_gpu_type() -> str:
     return "unknown"
 
 
-def detect_gpu_count() -> int:
-    """Return the number of visible NVIDIA GPUs (0 if nvidia-smi unavailable)."""
-    try:
-        result = subprocess.run(
-            ["nvidia-smi", "--query-gpu=count", "--format=csv,noheader"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            # nvidia-smi prints the count for every GPU (one line each); take any
-            return int(result.stdout.strip().split("\n")[0])
-    except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
-        pass
-    return 0
-
-
 def build_meta_header(
     model: str,
     profile_name: str,
@@ -119,20 +102,31 @@ def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
             "duration_seconds": round(req.request_duration_seconds, 4),
             "estimated": False,
         }
-    energy_j = req.energy_joules or 0.0
     output_tokens = req.completion_tokens or 0
     total_tokens = req.total_tokens or 0
     row: Dict[str, Any] = {
-        "energy_joules": round(energy_j, 4),
-        "avg_power_watts": round(req.avg_power_watts or 0.0, 1),
         "duration_seconds": round(req.request_duration_seconds, 4),
         "input_tokens": req.prompt_tokens,
         "output_tokens": output_tokens,
         "thinking_tokens": 0,
         "estimated": False,
-        "tokens_per_joule": round(total_tokens / energy_j, 4) if energy_j > 0 else 0,
-        "energy_per_useful_token": round(energy_j / output_tokens, 4) if output_tokens > 0 else 0,
     }
+    # Only emit energy fields when sampling actually produced data — emitting
+    # zeros for "no samples captured" silently looks like a successful 0 J run.
+    if req.energy_joules is not None:
+        energy_j = req.energy_joules
+        row["energy_joules"] = round(energy_j, 4)
+        row["avg_power_watts"] = round(req.avg_power_watts or 0.0, 1)
+        row["tokens_per_joule"] = round(total_tokens / energy_j, 4) if energy_j > 0 else 0
+        row["energy_per_useful_token"] = (
+            round(energy_j / output_tokens, 4) if output_tokens > 0 else 0
+        )
+    else:
+        row["energy_joules"] = None
+        row["avg_power_watts"] = None
+        row["tokens_per_joule"] = None
+        row["energy_per_useful_token"] = None
+        row["energy_attribution"] = "no-samples"
     return row
 
 

--- a/ai_energy_benchmarks/cli/single_stream.py
+++ b/ai_energy_benchmarks/cli/single_stream.py
@@ -36,6 +36,20 @@ from ..profiles.definitions import get_profile, is_multi_phase
 SINGLE_STREAM_PROFILES = ["single_stream_light", "single_stream_moderate", "single_stream_heavy"]
 
 
+def _positive_float(raw: str) -> float:
+    """argparse type validator: accept only strictly positive floats.
+
+    A zero or negative sample interval would either busy-loop nvidia-smi
+    (interval=0) or feed a negative duration to threading.Event.wait()
+    where behavior is implementation-defined. Reject up front instead
+    of producing nonsense measurements.
+    """
+    value = float(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"must be > 0 (got {raw!r})")
+    return value
+
+
 def detect_gpu_type() -> str:
     """Return normalized GPU model (e.g. 'A100', 'H200') from nvidia-smi."""
     try:
@@ -48,7 +62,11 @@ def detect_gpu_type() -> str:
         if result.returncode == 0:
             raw = result.stdout.strip().split("\n")[0]
             return raw.replace("NVIDIA ", "").replace("-", " ")
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (subprocess.TimeoutExpired, OSError):
+        # OSError covers FileNotFoundError (binary missing) and
+        # PermissionError (binary not executable in restricted envs).
+        # In both cases we want a graceful "unknown" fallback rather
+        # than aborting meta-header construction.
         pass
     return "unknown"
 
@@ -213,7 +231,7 @@ Profiles available (single-stream only — concurrency is always 1 here):
     )
     parser.add_argument(
         "--power-sample-interval",
-        type=float,
+        type=_positive_float,
         default=DEFAULT_POWER_SAMPLE_INTERVAL_S,
         help=f"GPU power sample interval in seconds (default: {DEFAULT_POWER_SAMPLE_INTERVAL_S})",
     )

--- a/ai_energy_benchmarks/cli/single_stream.py
+++ b/ai_energy_benchmarks/cli/single_stream.py
@@ -97,11 +97,14 @@ def build_meta_header(
 def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
     """Convert a RequestResult to the JSONL row shape downstream expects."""
     if req.error is not None:
-        return {
+        row_err: Dict[str, Any] = {
             "error": req.error,
             "duration_seconds": round(req.request_duration_seconds, 4),
             "estimated": False,
         }
+        if req.sample_errors is not None:
+            row_err["sample_errors"] = req.sample_errors
+        return row_err
     output_tokens = req.completion_tokens or 0
     total_tokens = req.total_tokens or 0
     row: Dict[str, Any] = {
@@ -127,6 +130,10 @@ def request_result_to_jsonl_row(req: Any) -> Dict[str, Any]:
         row["tokens_per_joule"] = None
         row["energy_per_useful_token"] = None
         row["energy_attribution"] = "no-samples"
+    # Sample-error count lets downstream audit measurement quality even when
+    # the energy figure looks plausible.
+    if req.sample_errors is not None:
+        row["sample_errors"] = req.sample_errors
     return row
 
 
@@ -272,7 +279,13 @@ Profiles available (single-stream only — concurrency is always 1 here):
         print(f"  avg power:    {result.avg_power_watts:.1f} W")
         print(f"  tok/J:        {result.tokens_per_joule:.3f}")
 
-    sys.exit(0 if result.successful_requests > 0 else 1)
+    # Exit non-zero when ANY requests failed, not just when none succeeded.
+    # The old `successful_requests > 0` check treated 19/20 failures as a
+    # successful run, which made CI/orchestrators silently merge bad data.
+    # Callers who tolerate partial failure can compare counts themselves.
+    if result.failed_requests > 0 or result.successful_requests == 0:
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/ai_energy_benchmarks/executors/__init__.py
+++ b/ai_energy_benchmarks/executors/__init__.py
@@ -2,10 +2,13 @@
 
 from .energy_aware import EnergyAwareExecutor, ProfileResult, RequestResult, run_sync
 from .genai_perf import GenAIPerfExecutor
+from .single_stream import GpuPowerSampler, SingleStreamExecutor
 
 __all__ = [
     "GenAIPerfExecutor",
     "EnergyAwareExecutor",
+    "SingleStreamExecutor",
+    "GpuPowerSampler",
     "RequestResult",
     "ProfileResult",
     "run_sync",

--- a/ai_energy_benchmarks/executors/energy_aware.py
+++ b/ai_energy_benchmarks/executors/energy_aware.py
@@ -37,6 +37,11 @@ class RequestResult:
     inference_duration_seconds: Optional[float] = None  # From energy.duration_seconds
     attribution_method: Optional[str] = None
     attribution_ratio: Optional[float] = None
+    # Number of failed power samples during this request (None if not tracked
+    # by the executor). Useful for auditing measurement quality: a request
+    # that reports energy but had many sample errors should be treated with
+    # suspicion.
+    sample_errors: Optional[int] = None
     # Error tracking
     error: Optional[str] = None
     status_code: Optional[int] = None

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -1,0 +1,351 @@
+"""Single-stream executor for on-box per-request energy measurement.
+
+This executor is the on-box equivalent of `EnergyAwareExecutor`: instead of
+reading per-request energy from an inference gateway's response (the
+`energy` field exposed by the NW gateway), it samples GPU power locally
+via `nvidia-smi` while each request is in flight and computes
+`energy_joules = avg_power_watts * duration_seconds` per request.
+
+This attribution is only valid at concurrency=1 — when requests don't
+overlap on the GPU, the sampled power belongs entirely to the request
+in flight. The executor enforces that by ignoring the profile's
+`concurrency` setting and running prompts serially.
+
+Workflow per request:
+    1. Start a background `GpuPowerSampler` thread.
+    2. POST one chat-completion to the vLLM endpoint synchronously.
+    3. Stop the sampler. Compute energy = avg_power * wall_clock_duration.
+    4. Append a `RequestResult` populated from the response usage and the
+       local power measurement.
+
+Use this for benchmarking raw vLLM (or any OpenAI-compatible endpoint
+that does not expose per-request energy in the response). For
+deployments where the endpoint exposes `energy` in the response, use
+`EnergyAwareExecutor` instead.
+"""
+
+import json
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from ..profiles import LoadProfileConfig
+from .energy_aware import (
+    EnergyAwareExecutor,
+    ProfileResult,
+    RequestResult,
+)
+
+DEFAULT_POWER_SAMPLE_INTERVAL_S = 0.1
+"""Default GPU power sampling interval in seconds.
+
+100 ms gives enough samples for short requests (1-2 s) without measurable
+overhead. Lower intervals don't improve accuracy because nvidia-smi
+itself caches its underlying NVML readings on a similar cadence.
+"""
+
+NVIDIA_SMI_TIMEOUT_S = 5
+"""Timeout for a single nvidia-smi power query.
+
+If a query stalls beyond this, we drop the sample and continue. nvidia-smi
+occasionally blocks on contended GPUs; dropping a sample is preferable to
+hanging the entire benchmark.
+"""
+
+
+class GpuPowerSampler:
+    """Sample total GPU power draw in a background thread.
+
+    Calls `nvidia-smi --query-gpu=power.draw` at a fixed interval and
+    averages all readings. Multi-GPU systems return the power of the
+    first GPU (index 0); a future enhancement could sum across GPUs for
+    multi-GPU vLLM tensor-parallel runs.
+
+    Not thread-safe across multiple concurrent users — the intended
+    usage is one sampler per request, in a single-stream loop.
+    """
+
+    def __init__(self, interval_s: float = DEFAULT_POWER_SAMPLE_INTERVAL_S):
+        self.interval_s = interval_s
+        self.samples: List[float] = []
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        self.samples = []
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._sample_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+
+    def _sample_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                result = subprocess.run(
+                    ["nvidia-smi", "--query-gpu=power.draw", "--format=csv,noheader,nounits"],
+                    capture_output=True,
+                    text=True,
+                    timeout=NVIDIA_SMI_TIMEOUT_S,
+                )
+                if result.returncode == 0:
+                    first_line = result.stdout.strip().split("\n")[0]
+                    self.samples.append(float(first_line))
+            except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
+                # ValueError: parse failure
+                # TimeoutExpired: nvidia-smi stalled
+                # FileNotFoundError: nvidia-smi not on PATH (e.g. mock test env)
+                pass
+            self._stop.wait(self.interval_s)
+
+    @property
+    def avg_power_watts(self) -> float:
+        if not self.samples:
+            return 0.0
+        return sum(self.samples) / len(self.samples)
+
+
+class SingleStreamExecutor:
+    """Run prompts one at a time and measure per-request GPU energy locally.
+
+    Forces concurrency=1 regardless of the profile's `concurrency` field,
+    because per-request energy attribution via power sampling is only
+    valid when requests don't overlap on the GPU.
+
+    Example:
+        from ai_energy_benchmarks.profiles.definitions import get_profile
+        executor = SingleStreamExecutor(seed=42)
+        result = executor.run(
+            profile=get_profile("single_stream_light"),
+            endpoint="http://localhost:8000/v1",
+            model="Qwen/Qwen3-32B",
+        )
+        for r in result.individual_results:
+            print(f"{r.total_tokens} tok, {r.energy_joules:.1f} J")
+    """
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        power_sample_interval_s: float = DEFAULT_POWER_SAMPLE_INTERVAL_S,
+    ):
+        """Initialize the executor.
+
+        Args:
+            seed: Random seed for reproducible prompt generation.
+            power_sample_interval_s: How often to sample GPU power during
+                a request, in seconds. Default 0.1 s.
+        """
+        self.seed = seed
+        self.power_sample_interval_s = power_sample_interval_s
+        # Reuse EnergyAwareExecutor's prompt generation so single-stream and
+        # gateway runs draw from the same prompt pool.
+        self._prompt_helper = EnergyAwareExecutor(seed=seed)
+
+    def run(
+        self,
+        profile: LoadProfileConfig,
+        endpoint: str,
+        model: str,
+        api_key: Optional[str] = None,
+        timeout_seconds: int = 120,
+    ) -> ProfileResult:
+        """Execute the profile single-stream and return aggregated results.
+
+        Args:
+            profile: Load profile config. `concurrency` is ignored (forced to 1).
+            endpoint: vLLM endpoint URL (e.g. "http://localhost:8000/v1").
+            model: Model name to use in the request.
+            api_key: Optional bearer token. Most local vLLM deployments
+                don't require one; pass None to skip the header.
+            timeout_seconds: Per-request HTTP timeout.
+
+        Returns:
+            ProfileResult with `individual_results` populated and energy
+            fields computed from local power sampling.
+        """
+        prompts = self._prompt_helper._generate_prompts(
+            profile.request_count, profile.input_token_range
+        )
+        max_tokens = profile.output_token_range[1]
+
+        endpoint = endpoint.rstrip("/")
+        if not endpoint.endswith("/v1") and "/v1" not in endpoint:
+            endpoint = f"{endpoint}/v1"
+
+        results: List[RequestResult] = []
+        sampler = GpuPowerSampler(interval_s=self.power_sample_interval_s)
+
+        wall_start = time.perf_counter()
+        for prompt in prompts:
+            results.append(
+                self._send_one_request(
+                    sampler, endpoint, model, api_key, prompt, max_tokens, timeout_seconds
+                )
+            )
+        wall_clock_seconds = time.perf_counter() - wall_start
+
+        return self._aggregate_results(
+            profile_name=profile.name,
+            model=model,
+            endpoint=endpoint,
+            results=results,
+            wall_clock_seconds=wall_clock_seconds,
+        )
+
+    def _send_one_request(
+        self,
+        sampler: GpuPowerSampler,
+        endpoint: str,
+        model: str,
+        api_key: Optional[str],
+        prompt: str,
+        max_tokens: int,
+        timeout_seconds: int,
+    ) -> RequestResult:
+        """Send one request with GPU power sampling and return a RequestResult."""
+        payload = json.dumps(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+            }
+        ).encode()
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        req = urllib.request.Request(f"{endpoint}/chat/completions", data=payload, headers=headers)
+
+        sampler.start()
+        t0 = time.perf_counter()
+        try:
+            with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+                body = resp.read()
+                status = resp.status
+        except urllib.error.HTTPError as e:
+            duration = time.perf_counter() - t0
+            sampler.stop()
+            return RequestResult(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                request_duration_seconds=duration,
+                error=f"HTTP {e.code}: {e.reason}",
+                status_code=e.code,
+            )
+        except Exception as e:
+            duration = time.perf_counter() - t0
+            sampler.stop()
+            return RequestResult(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                request_duration_seconds=duration,
+                error=str(e),
+            )
+
+        duration = time.perf_counter() - t0
+        sampler.stop()
+
+        avg_power = sampler.avg_power_watts
+        energy_j = avg_power * duration
+
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError as e:
+            return RequestResult(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                request_duration_seconds=duration,
+                error=f"JSON decode: {e}",
+                status_code=status,
+            )
+
+        usage = data.get("usage", {})
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        total_tokens = usage.get("total_tokens", prompt_tokens + completion_tokens)
+
+        return RequestResult(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            request_duration_seconds=duration,
+            energy_joules=energy_j,
+            energy_kwh=energy_j / 3_600_000.0,
+            avg_power_watts=avg_power,
+            inference_duration_seconds=duration,
+            attribution_method="local-power-sampling",
+            attribution_ratio=1.0,
+            status_code=status,
+        )
+
+    def _aggregate_results(
+        self,
+        profile_name: str,
+        model: str,
+        endpoint: str,
+        results: List[RequestResult],
+        wall_clock_seconds: float,
+    ) -> ProfileResult:
+        successful = [r for r in results if r.error is None]
+        failed = [r for r in results if r.error is not None]
+
+        total_tokens = sum(r.total_tokens for r in successful)
+        total_prompt_tokens = sum(r.prompt_tokens for r in successful)
+        total_completion_tokens = sum(r.completion_tokens for r in successful)
+        total_inference_seconds = sum(r.request_duration_seconds for r in successful)
+
+        tokens_per_second = (
+            total_completion_tokens / wall_clock_seconds if wall_clock_seconds > 0 else 0
+        )
+
+        energy_results = [r for r in successful if r.energy_joules is not None]
+        has_energy = len(energy_results) > 0
+
+        total_energy_j: Optional[float] = None
+        total_energy_kwh: Optional[float] = None
+        wh_per_request: Optional[float] = None
+        tokens_per_joule: Optional[float] = None
+        avg_power: Optional[float] = None
+
+        if has_energy:
+            total_energy_j = sum(r.energy_joules or 0.0 for r in energy_results)
+            total_energy_kwh = total_energy_j / 3_600_000.0
+            wh_per_request = (total_energy_kwh * 1000) / len(energy_results)
+            tokens_per_joule = total_tokens / total_energy_j if total_energy_j > 0 else None
+            power_readings = [r.avg_power_watts for r in energy_results if r.avg_power_watts]
+            avg_power = sum(power_readings) / len(power_readings) if power_readings else None
+
+        return ProfileResult(
+            profile_name=profile_name,
+            model=model,
+            endpoint=endpoint,
+            timestamp=datetime.now(timezone.utc),
+            request_count=len(results),
+            successful_requests=len(successful),
+            failed_requests=len(failed),
+            concurrency=1,
+            total_tokens=total_tokens,
+            total_prompt_tokens=total_prompt_tokens,
+            total_completion_tokens=total_completion_tokens,
+            total_wall_clock_seconds=wall_clock_seconds,
+            total_inference_seconds=total_inference_seconds,
+            tokens_per_second=tokens_per_second,
+            total_energy_joules=total_energy_j,
+            total_energy_kwh=total_energy_kwh,
+            wh_per_request=wh_per_request,
+            tokens_per_joule=tokens_per_joule,
+            avg_power_watts=avg_power,
+            energy_available=has_energy,
+            individual_results=results,
+        )

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -26,6 +26,7 @@ deployments where the endpoint exposes `energy` in the response, use
 
 import hashlib
 import json
+import logging
 import random
 import subprocess
 import threading
@@ -40,6 +41,8 @@ from .energy_aware import (
     ProfileResult,
     RequestResult,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_POWER_SAMPLE_INTERVAL_S = 0.1
 """Default GPU power sampling interval in seconds.
@@ -56,6 +59,13 @@ If a query stalls beyond this, we drop the sample and continue. nvidia-smi
 occasionally blocks on contended GPUs; dropping a sample is preferable to
 hanging the entire benchmark.
 """
+
+SAMPLE_ERROR_WARN_RATIO = 0.25
+"""Warn the operator when more than this fraction of nvidia-smi calls for a
+single request failed. At >25% error rate the avg-power figure has lost
+enough samples that the per-request energy number is no longer trustworthy,
+even though we still report it (since it's better than silently dropping
+the request)."""
 
 # Base prompts for generating varied requests. Duplicated from
 # EnergyAwareExecutor.BASE_PROMPTS so this executor doesn't pull in the
@@ -158,11 +168,16 @@ class GpuPowerSampler:
     def __init__(self, interval_s: float = DEFAULT_POWER_SAMPLE_INTERVAL_S):
         self.interval_s = interval_s
         self.samples: List[float] = []
+        # Track sample-loop failures separately so callers can audit data
+        # quality. Silent timeouts/parse errors would otherwise just shrink
+        # the average without any signal that some readings were lost.
+        self.sample_errors: int = 0
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
 
     def start(self) -> None:
         self.samples = []
+        self.sample_errors = 0
         self._stop.clear()
         self._thread = threading.Thread(target=self._sample_loop, daemon=True)
         self._thread.start()
@@ -193,11 +208,13 @@ class GpuPowerSampler:
                 if result.returncode == 0:
                     first_line = result.stdout.strip().split("\n")[0]
                     self.samples.append(float(first_line))
+                else:
+                    self.sample_errors += 1
             except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
                 # ValueError: parse failure
                 # TimeoutExpired: nvidia-smi stalled
                 # FileNotFoundError: nvidia-smi not on PATH (e.g. mock test env)
-                pass
+                self.sample_errors += 1
             self._stop.wait(self.interval_s)
 
     @property
@@ -337,6 +354,7 @@ class SingleStreamExecutor:
                 completion_tokens=0,
                 total_tokens=0,
                 request_duration_seconds=duration,
+                sample_errors=sampler.sample_errors,
                 error=f"HTTP {e.code}: {e.reason}",
                 status_code=e.code,
             )
@@ -348,11 +366,24 @@ class SingleStreamExecutor:
                 completion_tokens=0,
                 total_tokens=0,
                 request_duration_seconds=duration,
+                sample_errors=sampler.sample_errors,
                 error=str(e),
             )
 
         duration = time.perf_counter() - t0
         sampler.stop()
+
+        sample_errors = sampler.sample_errors
+        sample_count = len(sampler.samples)
+        total_attempts = sample_count + sample_errors
+        if total_attempts > 0 and sample_errors / total_attempts > SAMPLE_ERROR_WARN_RATIO:
+            logger.warning(
+                "nvidia-smi sample-error rate %.0f%% (%d errors / %d attempts) "
+                "for this request — energy figure may be unreliable",
+                100.0 * sample_errors / total_attempts,
+                sample_errors,
+                total_attempts,
+            )
 
         # If nvidia-smi was missing, timed out, or returned unparseable
         # output for every sample, we have no power data for this request.
@@ -399,6 +430,7 @@ class SingleStreamExecutor:
             inference_duration_seconds=duration if energy_j is not None else None,
             attribution_method=attribution,
             attribution_ratio=1.0 if energy_j is not None else None,
+            sample_errors=sample_errors,
             status_code=status,
         )
 

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -472,9 +472,7 @@ class SingleStreamExecutor:
             # would inflate the metric when some requests lost power data —
             # numerator and denominator must come from the same set.
             energy_token_total = sum(r.total_tokens for r in energy_results)
-            tokens_per_joule = (
-                energy_token_total / total_energy_j if total_energy_j > 0 else None
-            )
+            tokens_per_joule = energy_token_total / total_energy_j if total_energy_j > 0 else None
             power_readings = [r.avg_power_watts for r in energy_results if r.avg_power_watts]
             avg_power = sum(power_readings) / len(power_readings) if power_readings else None
 

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -467,7 +467,14 @@ class SingleStreamExecutor:
             total_energy_j = sum(r.energy_joules or 0.0 for r in energy_results)
             total_energy_kwh = total_energy_j / 3_600_000.0
             wh_per_request = (total_energy_kwh * 1000) / len(energy_results)
-            tokens_per_joule = total_tokens / total_energy_j if total_energy_j > 0 else None
+            # tokens_per_joule must divide tokens from the SAME requests whose
+            # energy we summed. Using `total_tokens` (all successful) here
+            # would inflate the metric when some requests lost power data —
+            # numerator and denominator must come from the same set.
+            energy_token_total = sum(r.total_tokens for r in energy_results)
+            tokens_per_joule = (
+                energy_token_total / total_energy_j if total_energy_j > 0 else None
+            )
             power_readings = [r.avg_power_watts for r in energy_results if r.avg_power_watts]
             avg_power = sum(power_readings) / len(power_readings) if power_readings else None
 

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -12,7 +12,7 @@ in flight. The executor enforces that by ignoring the profile's
 `concurrency` setting and running prompts serially.
 
 Workflow per request:
-    1. Start a background `GpuPowerSampler` thread.
+    1. Start a fresh background `GpuPowerSampler` thread.
     2. POST one chat-completion to the vLLM endpoint synchronously.
     3. Stop the sampler. Compute energy = avg_power * wall_clock_duration.
     4. Append a `RequestResult` populated from the response usage and the
@@ -24,7 +24,9 @@ deployments where the endpoint exposes `energy` in the response, use
 `EnergyAwareExecutor` instead.
 """
 
+import hashlib
 import json
+import random
 import subprocess
 import threading
 import time
@@ -35,7 +37,6 @@ from typing import List, Optional
 
 from ..profiles import LoadProfileConfig
 from .energy_aware import (
-    EnergyAwareExecutor,
     ProfileResult,
     RequestResult,
 )
@@ -55,6 +56,91 @@ If a query stalls beyond this, we drop the sample and continue. nvidia-smi
 occasionally blocks on contended GPUs; dropping a sample is preferable to
 hanging the entire benchmark.
 """
+
+# Base prompts for generating varied requests. Duplicated from
+# EnergyAwareExecutor.BASE_PROMPTS so this executor doesn't pull in the
+# aiohttp dependency just to share a list of strings.
+_BASE_PROMPTS = [
+    "Explain the concept of machine learning and its applications in modern technology.",
+    "Describe the process of photosynthesis and its importance in the ecosystem.",
+    "What are the key principles of object-oriented programming?",
+    "Discuss the history and significance of the Renaissance period.",
+    "Explain the fundamentals of quantum physics and quantum computing.",
+    "Describe the structure and function of DNA in living organisms.",
+    "What are the main causes and effects of climate change?",
+    "Explain the principles of supply and demand in economics.",
+    "Describe the process of cellular respiration in biological systems.",
+    "What are the key components of a computer operating system?",
+    "Explain the concept of neural networks and deep learning.",
+    "Describe the major events of World War II and their global impact.",
+    "What are the fundamental principles of thermodynamics?",
+    "Explain how blockchain technology works and its applications.",
+    "Describe the structure and function of the human immune system.",
+]
+
+_CONTENT_BLOCKS = [
+    "Please provide detailed examples and explanations with specific use cases.",
+    "Include practical applications and real-world scenarios where this applies.",
+    "Discuss the historical context, development, and evolution over time.",
+    "Explain the technical details, mechanisms, and underlying principles involved.",
+    "Compare and contrast with related concepts, alternatives, and similar approaches.",
+    "Analyze the advantages, disadvantages, trade-offs, and considerations.",
+    "Provide step-by-step instructions, processes, and implementation guidelines.",
+    "Include relevant statistics, data, research findings, and empirical evidence.",
+    "Discuss future trends, developments, predictions, and potential innovations.",
+    "Explain the impact on society, industry, economics, and various stakeholders.",
+    "Describe the key components, architecture, structure, and organization.",
+    "Outline the methodology, approach, framework, and best practices.",
+    "Address common challenges, problems, limitations, and how to overcome them.",
+    "Discuss security implications, risks, vulnerabilities, and mitigation strategies.",
+    "Explain performance characteristics, optimization techniques, and efficiency.",
+    "Cover testing strategies, validation methods, and quality assurance approaches.",
+    "Describe integration patterns, compatibility considerations, and interoperability.",
+    "Discuss scalability aspects, growth considerations, and capacity planning.",
+    "Explain maintenance requirements, operational procedures, and lifecycle management.",
+    "Address regulatory compliance, standards, certifications, and legal considerations.",
+]
+
+
+def _generate_prompts(
+    count: int,
+    input_token_range: tuple,
+    seed: Optional[int],
+    rng: random.Random,
+) -> List[str]:
+    """Generate deterministic prompts matching EnergyAwareExecutor's format.
+
+    Standalone helper (no aiohttp dependency) so SingleStreamExecutor can
+    run in minimal installs. The output is character-for-character
+    identical to EnergyAwareExecutor._generate_prompts for the same seed
+    and input_token_range — both executors draw from the same prompt
+    pool, so cross-executor comparisons remain apples-to-apples.
+    """
+    prompts: List[str] = []
+    min_tokens, max_tokens = input_token_range
+    for i in range(count):
+        base_prompt = _BASE_PROMPTS[i % len(_BASE_PROMPTS)]
+        if seed is not None:
+            unique_id = hashlib.md5(f"{seed}_{i}".encode()).hexdigest()[:8]
+        else:
+            unique_id = hashlib.md5(f"{time.time()}_{i}".encode()).hexdigest()[:8]
+        prompt = f"[Request {i + 1}/{count}, ID:{unique_id}] " + base_prompt
+
+        target_tokens = rng.randint(min_tokens, max_tokens)
+        estimated_tokens = len(prompt) // 4  # ~4 chars/token
+        block_index = 0
+        while estimated_tokens < target_tokens:
+            block = _CONTENT_BLOCKS[block_index % len(_CONTENT_BLOCKS)]
+            if block_index >= len(_CONTENT_BLOCKS):
+                variation = f" (aspect {block_index // len(_CONTENT_BLOCKS) + 1})"
+                block = block.rstrip(".") + variation + "."
+            prompt += " " + block
+            estimated_tokens = len(prompt) // 4
+            block_index += 1
+            if block_index > 200:
+                break
+        prompts.append(prompt)
+    return prompts
 
 
 class GpuPowerSampler:
@@ -82,9 +168,18 @@ class GpuPowerSampler:
         self._thread.start()
 
     def stop(self) -> None:
+        """Signal the sample loop to exit and wait for the thread to terminate.
+
+        The join timeout must exceed `NVIDIA_SMI_TIMEOUT_S` because the loop
+        body can block in `subprocess.run(nvidia-smi)` for up to that long.
+        A timeout shorter than NVIDIA_SMI_TIMEOUT_S can leave the thread
+        alive after stop() returns, which (together with sampler reuse)
+        causes cross-request sample contamination. Add a small interval
+        buffer for the post-call `_stop.wait(interval_s)` sleep.
+        """
         self._stop.set()
         if self._thread:
-            self._thread.join(timeout=2)
+            self._thread.join(timeout=NVIDIA_SMI_TIMEOUT_S + self.interval_s + 1.0)
 
     def _sample_loop(self) -> None:
         while not self._stop.is_set():
@@ -145,9 +240,7 @@ class SingleStreamExecutor:
         """
         self.seed = seed
         self.power_sample_interval_s = power_sample_interval_s
-        # Reuse EnergyAwareExecutor's prompt generation so single-stream and
-        # gateway runs draw from the same prompt pool.
-        self._prompt_helper = EnergyAwareExecutor(seed=seed)
+        self._random = random.Random(seed) if seed is not None else random.Random()
 
     def run(
         self,
@@ -171,8 +264,11 @@ class SingleStreamExecutor:
             ProfileResult with `individual_results` populated and energy
             fields computed from local power sampling.
         """
-        prompts = self._prompt_helper._generate_prompts(
-            profile.request_count, profile.input_token_range
+        prompts = _generate_prompts(
+            profile.request_count,
+            profile.input_token_range,
+            self.seed,
+            self._random,
         )
         max_tokens = profile.output_token_range[1]
 
@@ -181,10 +277,13 @@ class SingleStreamExecutor:
             endpoint = f"{endpoint}/v1"
 
         results: List[RequestResult] = []
-        sampler = GpuPowerSampler(interval_s=self.power_sample_interval_s)
-
         wall_start = time.perf_counter()
         for prompt in prompts:
+            # Fresh sampler per request prevents cross-request sample
+            # contamination if a prior nvidia-smi call is still in flight
+            # when stop() returns. Constructing a sampler is cheap (no
+            # threads spawned until start()).
+            sampler = GpuPowerSampler(interval_s=self.power_sample_interval_s)
             results.append(
                 self._send_one_request(
                     sampler, endpoint, model, api_key, prompt, max_tokens, timeout_seconds
@@ -255,8 +354,22 @@ class SingleStreamExecutor:
         duration = time.perf_counter() - t0
         sampler.stop()
 
-        avg_power = sampler.avg_power_watts
-        energy_j = avg_power * duration
+        # If nvidia-smi was missing, timed out, or returned unparseable
+        # output for every sample, we have no power data for this request.
+        # Reporting energy_joules=0 in that case would silently produce
+        # invalid benchmark output (downstream would treat 0 J as real,
+        # not as missing). Leave energy fields None — downstream
+        # aggregation already filters by `energy_joules is not None`.
+        if not sampler.samples:
+            energy_j: Optional[float] = None
+            energy_kwh: Optional[float] = None
+            avg_power: Optional[float] = None
+            attribution: Optional[str] = None
+        else:
+            avg_power = sampler.avg_power_watts
+            energy_j = avg_power * duration
+            energy_kwh = energy_j / 3_600_000.0
+            attribution = "local-power-sampling"
 
         try:
             data = json.loads(body)
@@ -281,11 +394,11 @@ class SingleStreamExecutor:
             total_tokens=total_tokens,
             request_duration_seconds=duration,
             energy_joules=energy_j,
-            energy_kwh=energy_j / 3_600_000.0,
+            energy_kwh=energy_kwh,
             avg_power_watts=avg_power,
-            inference_duration_seconds=duration,
-            attribution_method="local-power-sampling",
-            attribution_ratio=1.0,
+            inference_duration_seconds=duration if energy_j is not None else None,
+            attribution_method=attribution,
+            attribution_ratio=1.0 if energy_j is not None else None,
             status_code=status,
         )
 

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -157,9 +157,11 @@ class GpuPowerSampler:
     """Sample total GPU power draw in a background thread.
 
     Calls `nvidia-smi --query-gpu=power.draw` at a fixed interval and
-    averages all readings. Multi-GPU systems return the power of the
-    first GPU (index 0); a future enhancement could sum across GPUs for
-    multi-GPU vLLM tensor-parallel runs.
+    averages the per-sample readings. On multi-GPU systems (e.g. vLLM
+    `--tensor-parallel N`) the readings from every visible GPU are
+    summed at each sample so the per-request `avg_power_watts` reflects
+    total board power, not just GPU 0. A partial sample (one GPU's line
+    unparseable) is dropped entirely and counted as a sample error.
 
     Not thread-safe across multiple concurrent users — the intended
     usage is one sampler per request, in a single-stream loop.
@@ -206,8 +208,17 @@ class GpuPowerSampler:
                     timeout=NVIDIA_SMI_TIMEOUT_S,
                 )
                 if result.returncode == 0:
-                    first_line = result.stdout.strip().split("\n")[0]
-                    self.samples.append(float(first_line))
+                    # Sum power across every visible GPU. nvidia-smi emits one
+                    # line per GPU; for `--tensor-parallel N` the model spans
+                    # N GPUs and reporting only line 0 would undercount energy
+                    # by ~N×. A blank line (rare on multi-GPU boxes) is
+                    # skipped; a non-numeric line raises ValueError, which we
+                    # catch below and count as a sample error so a malformed
+                    # reading doesn't silently truncate the per-GPU sum.
+                    lines = [line for line in result.stdout.strip().split("\n") if line.strip()]
+                    if not lines:
+                        raise ValueError("nvidia-smi returned no GPU lines")
+                    self.samples.append(sum(float(line) for line in lines))
                 else:
                     self.sample_errors += 1
             except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -131,9 +131,11 @@ def _generate_prompts(
     for i in range(count):
         base_prompt = _BASE_PROMPTS[i % len(_BASE_PROMPTS)]
         if seed is not None:
-            unique_id = hashlib.md5(f"{seed}_{i}".encode()).hexdigest()[:8]
+            unique_id = hashlib.md5(f"{seed}_{i}".encode(), usedforsecurity=False).hexdigest()[:8]
         else:
-            unique_id = hashlib.md5(f"{time.time()}_{i}".encode()).hexdigest()[:8]
+            unique_id = hashlib.md5(
+                f"{time.time()}_{i}".encode(), usedforsecurity=False
+            ).hexdigest()[:8]
         prompt = f"[Request {i + 1}/{count}, ID:{unique_id}] " + base_prompt
 
         target_tokens = rng.randint(min_tokens, max_tokens)
@@ -220,6 +222,15 @@ class GpuPowerSampler:
                         raise ValueError("nvidia-smi returned no GPU lines")
                     self.samples.append(sum(float(line) for line in lines))
                 else:
+                    # Log stderr at debug so operators can diagnose root cause
+                    # (driver/NVML state, permissions, etc.). Without this, the
+                    # 25%-error warning tells them *that* sampling failed but
+                    # not *why*.
+                    logger.debug(
+                        "nvidia-smi failed (rc=%d): %s",
+                        result.returncode,
+                        result.stderr.strip(),
+                    )
                     self.sample_errors += 1
             except (ValueError, subprocess.TimeoutExpired, OSError):
                 # ValueError: parse failure

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -405,11 +405,23 @@ class SingleStreamExecutor:
         try:
             data = json.loads(body)
         except json.JSONDecodeError as e:
+            # The HTTP request completed and the sampler ran cleanly — the
+            # energy measurement is still valid even though we can't parse
+            # token counts. Carry energy + sample_errors through so the
+            # downstream auditing stays consistent with the HTTP-error and
+            # generic-exception paths above.
             return RequestResult(
                 prompt_tokens=0,
                 completion_tokens=0,
                 total_tokens=0,
                 request_duration_seconds=duration,
+                energy_joules=energy_j,
+                energy_kwh=energy_kwh,
+                avg_power_watts=avg_power,
+                inference_duration_seconds=duration if energy_j is not None else None,
+                attribution_method=attribution,
+                attribution_ratio=1.0 if energy_j is not None else None,
+                sample_errors=sample_errors,
                 error=f"JSON decode: {e}",
                 status_code=status,
             )

--- a/ai_energy_benchmarks/executors/single_stream.py
+++ b/ai_energy_benchmarks/executors/single_stream.py
@@ -221,10 +221,16 @@ class GpuPowerSampler:
                     self.samples.append(sum(float(line) for line in lines))
                 else:
                     self.sample_errors += 1
-            except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
+            except (ValueError, subprocess.TimeoutExpired, OSError):
                 # ValueError: parse failure
                 # TimeoutExpired: nvidia-smi stalled
-                # FileNotFoundError: nvidia-smi not on PATH (e.g. mock test env)
+                # OSError: covers FileNotFoundError (binary missing on PATH,
+                # e.g. mock test envs) AND PermissionError (binary present
+                # but not executable, e.g. restrictive container seccomp /
+                # bind-mount without +x). Catching only FileNotFoundError
+                # would let PermissionError kill the background sampler
+                # thread silently, leaving the request with no energy
+                # measurement and no `sample_errors` audit trail.
                 self.sample_errors += 1
             self._stop.wait(self.interval_s)
 

--- a/ai_energy_benchmarks/profiles/definitions.py
+++ b/ai_energy_benchmarks/profiles/definitions.py
@@ -222,6 +222,50 @@ def get_long_tokens_profile() -> LoadProfileConfig:
     )
 
 
+# Single-stream profiles - concurrency=1, one request at a time. Designed to
+# match the methodology of public intelligence benchmarks (e.g. Artificial
+# Analysis) that issue prompts serially without batching. Useful as a clean
+# per-request energy baseline that is comparable across hardware without
+# concurrency confounding the measurement.
+def get_single_stream_light_profile() -> LoadProfileConfig:
+    """Get the single-stream light profile (concurrency=1, short outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_light",
+        description="Single-stream light - concurrency=1, short outputs (~100-200 tokens)",
+        concurrency=1,
+        request_count=30,
+        input_token_range=(50, 150),
+        output_token_range=(100, 200),
+        cache_strategy="minimal",
+    )
+
+
+def get_single_stream_moderate_profile() -> LoadProfileConfig:
+    """Get the single-stream moderate profile (concurrency=1, medium outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_moderate",
+        description="Single-stream moderate - concurrency=1, medium outputs (~200-500 tokens)",
+        concurrency=1,
+        request_count=30,
+        input_token_range=(50, 150),
+        output_token_range=(200, 500),
+        cache_strategy="minimal",
+    )
+
+
+def get_single_stream_heavy_profile() -> LoadProfileConfig:
+    """Get the single-stream heavy profile (concurrency=1, long outputs)."""
+    return LoadProfileConfig(
+        name="single_stream_heavy",
+        description="Single-stream heavy - concurrency=1, long outputs (~500-1000 tokens)",
+        concurrency=1,
+        request_count=20,
+        input_token_range=(50, 150),
+        output_token_range=(500, 1000),
+        cache_strategy="minimal",
+    )
+
+
 # Profile registry - lazy initialized and cached
 _PROFILES_CACHE: Optional[Dict[str, Union[LoadProfileConfig, MultiPhaseProfile]]] = None
 
@@ -246,6 +290,10 @@ def _get_profiles_registry() -> MappingProxyType:
             "short_tokens": get_short_tokens_profile(),
             "long_input_short_output": get_long_input_short_output_profile(),
             "long_tokens": get_long_tokens_profile(),
+            # Single-stream profiles (concurrency=1, AA-comparable)
+            "single_stream_light": get_single_stream_light_profile(),
+            "single_stream_moderate": get_single_stream_moderate_profile(),
+            "single_stream_heavy": get_single_stream_heavy_profile(),
         }
     return MappingProxyType(_PROFILES_CACHE)
 
@@ -254,7 +302,9 @@ def get_profile(name: str) -> Union[LoadProfileConfig, MultiPhaseProfile]:
     """Get a profile by name.
 
     Args:
-        name: Profile name (light, moderate, heavy, stress, multiphase, pattern, power_test)
+        name: Profile name (light, moderate, heavy, stress, multiphase, pattern,
+            power_test, short_tokens, long_input_short_output, long_tokens,
+            single_stream_light, single_stream_moderate, single_stream_heavy)
 
     Returns:
         LoadProfileConfig or MultiPhaseProfile
@@ -310,5 +360,8 @@ __all__ = [
     "get_short_tokens_profile",
     "get_long_input_short_output_profile",
     "get_long_tokens_profile",
+    "get_single_stream_light_profile",
+    "get_single_stream_moderate_profile",
+    "get_single_stream_heavy_profile",
     "PROFILES",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ Issues = "https://github.com/neuralwatt/ai_energy_benchmarks/issues"
 
 [project.scripts]
 ai-energy-profile = "ai_energy_benchmarks.cli.profile:main"
+ai-energy-single-stream = "ai_energy_benchmarks.cli.single_stream:main"
 
 [tool.setuptools.dynamic]
 version = {file = "VERSION.txt"}

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -15,6 +15,9 @@ from ai_energy_benchmarks.profiles.definitions import (
     get_power_test_profile,
     get_profile,
     get_short_tokens_profile,
+    get_single_stream_heavy_profile,
+    get_single_stream_light_profile,
+    get_single_stream_moderate_profile,
     get_stress_profile,
     is_multi_phase,
     list_profiles,
@@ -237,6 +240,36 @@ class TestProfileDefinitions:
         assert profile.input_token_range == (1000, 2000)
         assert profile.output_token_range == (1000, 2000)
 
+    def test_get_single_stream_light_profile(self):
+        """Test single_stream_light profile definition."""
+        profile = get_single_stream_light_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_light"
+        assert profile.concurrency == 1
+        assert profile.request_count == 30
+        assert profile.output_token_range == (100, 200)
+
+    def test_get_single_stream_moderate_profile(self):
+        """Test single_stream_moderate profile definition."""
+        profile = get_single_stream_moderate_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_moderate"
+        assert profile.concurrency == 1
+        assert profile.request_count == 30
+        assert profile.output_token_range == (200, 500)
+
+    def test_get_single_stream_heavy_profile(self):
+        """Test single_stream_heavy profile definition."""
+        profile = get_single_stream_heavy_profile()
+
+        assert isinstance(profile, LoadProfileConfig)
+        assert profile.name == "single_stream_heavy"
+        assert profile.concurrency == 1
+        assert profile.request_count == 20
+        assert profile.output_token_range == (500, 1000)
+
 
 class TestProfileRegistry:
     """Tests for profile registry functions."""
@@ -257,7 +290,11 @@ class TestProfileRegistry:
         assert "short_tokens" in profiles
         assert "long_input_short_output" in profiles
         assert "long_tokens" in profiles
-        assert len(profiles) == 10
+        # Single-stream profiles
+        assert "single_stream_light" in profiles
+        assert "single_stream_moderate" in profiles
+        assert "single_stream_heavy" in profiles
+        assert len(profiles) == 13
 
     def test_get_profile_valid(self):
         """Test get_profile returns correct profile for valid names."""
@@ -283,6 +320,10 @@ class TestProfileRegistry:
         assert is_multi_phase(get_short_tokens_profile()) is False
         assert is_multi_phase(get_long_input_short_output_profile()) is False
         assert is_multi_phase(get_long_tokens_profile()) is False
+        # Single-stream profiles are also single-phase
+        assert is_multi_phase(get_single_stream_light_profile()) is False
+        assert is_multi_phase(get_single_stream_moderate_profile()) is False
+        assert is_multi_phase(get_single_stream_heavy_profile()) is False
 
     def test_is_multi_phase_multi(self):
         """Test is_multi_phase returns True for multi-phase profiles."""
@@ -293,7 +334,7 @@ class TestProfileRegistry:
     def test_profiles_registry_populated(self):
         """Test profiles registry is populated correctly."""
         profiles = _get_profiles_registry()
-        assert len(profiles) == 10
+        assert len(profiles) == 13
         assert all(name in profiles for name in list_profiles())
 
 
@@ -335,6 +376,9 @@ class TestProfileConsistency:
             "short_tokens",
             "long_input_short_output",
             "long_tokens",
+            "single_stream_light",
+            "single_stream_moderate",
+            "single_stream_heavy",
         ]
         for name in single_phase_profiles:
             profile = get_profile(name)

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -456,6 +456,46 @@ class TestSingleStreamExecutor:
 
         assert not any("sample-error rate" in r.message for r in caplog.records)
 
+    def test_json_decode_error_preserves_energy_and_sample_errors(self):
+        """When the HTTP response is 200 but the body isn't valid JSON, the
+        RequestResult must still carry the energy measurement and
+        sample_errors. The sampler ran cleanly across the request — that
+        data is valid and downstream auditing depends on it.
+
+        Regression: a glm-5.1-flex review caught that this code path returned
+        a bare error result, silently dropping the already-computed
+        energy_joules / avg_power_watts / sample_errors fields.
+        """
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        def _start_with_data(self):
+            self.samples = [250.0, 250.0, 250.0]
+            self.sample_errors = 2
+
+        with (
+            patch.object(GpuPowerSampler, "start", _start_with_data),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch.object(
+                GpuPowerSampler,
+                "avg_power_watts",
+                new=property(lambda self: 250.0),
+            ),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(b"not valid json {{{"),
+            ),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        req = result.individual_results[0]
+        assert req.error is not None and "JSON decode" in req.error
+        assert req.sample_errors == 2
+        assert req.avg_power_watts == 250.0
+        assert req.energy_joules is not None
+        assert req.energy_joules > 0
+        assert req.attribution_method == "local-power-sampling"
+
     def test_aggregate_tokens_per_joule_uses_total_tokens(self, deterministic_sampler):
         """tokens_per_joule = sum(total_tokens) / sum(energy_joules).
 

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -1,6 +1,7 @@
 """Tests for SingleStreamExecutor and its CLI."""
 
 import json
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -61,11 +62,16 @@ class _FakeUrlopenResponse:
 def deterministic_sampler():
     """Force GpuPowerSampler to return a fixed avg_power_watts.
 
-    Avoids depending on a real nvidia-smi in CI. The threading start/stop
-    behaviour is bypassed entirely so tests don't sleep.
+    Avoids depending on a real nvidia-smi in CI. start() seeds a single
+    sample so the executor's `if not sampler.samples` branch treats this
+    as a real measurement; stop() is a no-op so we don't sleep.
     """
+
+    def _seed_sample(self):
+        self.samples = [250.0]
+
     with (
-        patch.object(GpuPowerSampler, "start", lambda self: None),
+        patch.object(GpuPowerSampler, "start", _seed_sample),
         patch.object(GpuPowerSampler, "stop", lambda self: None),
         patch.object(
             GpuPowerSampler,
@@ -243,6 +249,85 @@ class TestSingleStreamExecutor:
         merged = {k.lower(): v for k, v in captured_headers[0].items()}
         assert merged.get("authorization") == "Bearer sk-test"
 
+    def test_no_power_samples_yields_none_energy(self):
+        """When the sampler collects zero samples, the request must report
+        energy_joules=None — never a silent 0.0 that downstream would treat
+        as a real measurement.
+
+        Regression: a previous version reported 0.0 J / 0.0 W with
+        attribution_method="local-power-sampling" when nvidia-smi was
+        missing or every query timed out, producing benchmark output that
+        looked valid but wasn't.
+        """
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        # Sampler captures nothing: start/stop are no-ops, samples stays empty.
+        with (
+            patch.object(GpuPowerSampler, "start", lambda self: None),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(_make_chat_response()),
+            ),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert result.successful_requests == 1
+        req = result.individual_results[0]
+        assert req.energy_joules is None
+        assert req.energy_kwh is None
+        assert req.avg_power_watts is None
+        assert req.attribution_method is None
+        assert req.attribution_ratio is None
+        # Token counts still come from the HTTP response — those are unaffected
+        # by the absence of power data.
+        assert req.total_tokens == 150
+        # Aggregate must flag energy_available=False so downstream skips
+        # the run rather than ingesting zeros.
+        assert result.energy_available is False
+        assert result.total_energy_joules is None
+
+    def test_fresh_sampler_per_request_isolates_samples(self):
+        """The executor must construct a new GpuPowerSampler for every
+        request — reusing one risks cross-request sample contamination
+        if a prior nvidia-smi call is still in flight when stop() returns.
+        """
+        profile = _make_profile(request_count=3)
+        executor = SingleStreamExecutor(seed=42)
+
+        constructed: List[GpuPowerSampler] = []
+        real_init = GpuPowerSampler.__init__
+
+        def _tracking_init(self, *args, **kwargs):
+            real_init(self, *args, **kwargs)
+            constructed.append(self)
+
+        with (
+            patch.object(GpuPowerSampler, "__init__", _tracking_init),
+            patch.object(GpuPowerSampler, "start", lambda self: None),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch.object(
+                GpuPowerSampler,
+                "avg_power_watts",
+                new=property(lambda self: 250.0),
+            ),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(_make_chat_response()),
+            ),
+        ):
+            # Force the avg_power_watts path by giving every sampler a sample
+            def _start_with_sample(self):
+                self.samples = [250.0]
+
+            with patch.object(GpuPowerSampler, "start", _start_with_sample):
+                executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        # One sampler per request — no reuse.
+        assert len(constructed) == 3
+        assert len({id(s) for s in constructed}) == 3
+
     def test_aggregate_tokens_per_joule_uses_total_tokens(self, deterministic_sampler):
         """tokens_per_joule = sum(total_tokens) / sum(energy_joules).
 
@@ -332,6 +417,41 @@ class TestCliOutputFormat:
         # use abs tolerance that accommodates that rounding.
         assert row["tokens_per_joule"] == pytest.approx(100 / 125.0, abs=1e-4)
         assert row["energy_per_useful_token"] == pytest.approx(125.0 / 70, abs=1e-4)
+
+    def test_request_row_for_missing_energy_is_null_not_zero(self):
+        """When sampling captured no data, the row must serialize energy
+        fields as null and tag energy_attribution='no-samples' — never
+        emit zeros that downstream would mistake for a real reading.
+
+        Regression: previous behaviour emitted energy_joules=0.0,
+        tokens_per_joule=0, which silently corrupted downstream aggregates.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=30,
+            completion_tokens=70,
+            total_tokens=100,
+            request_duration_seconds=0.5,
+            energy_joules=None,
+            energy_kwh=None,
+            avg_power_watts=None,
+            inference_duration_seconds=None,
+            attribution_method=None,
+            attribution_ratio=None,
+            status_code=200,
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert row["energy_joules"] is None
+        assert row["avg_power_watts"] is None
+        assert row["tokens_per_joule"] is None
+        assert row["energy_per_useful_token"] is None
+        assert row["energy_attribution"] == "no-samples"
+        # Token / duration data is unaffected by missing power samples
+        assert row["input_tokens"] == 30
+        assert row["output_tokens"] == 70
+        assert row["duration_seconds"] == 0.5
 
     def test_request_row_for_failed_request_is_error_only(self):
         """Failed requests must serialize without bogus zero energy fields

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -461,9 +461,9 @@ class TestSingleStreamExecutor:
         ):
             executor.run(profile, "http://localhost:8000/v1", "test-model")
 
-        assert any("sample-error rate" in r.message for r in caplog.records), (
-            f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
-        )
+        assert any(
+            "sample-error rate" in r.message for r in caplog.records
+        ), f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
 
     def test_executor_does_not_warn_when_sample_error_rate_low(self, caplog):
         """Quiet runs must stay quiet — no warning for a small handful of

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -1,0 +1,377 @@
+"""Tests for SingleStreamExecutor and its CLI."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_energy_benchmarks.executors.single_stream import (
+    GpuPowerSampler,
+    SingleStreamExecutor,
+)
+from ai_energy_benchmarks.profiles import LoadProfileConfig
+
+
+def _make_profile(request_count: int = 2) -> LoadProfileConfig:
+    """Build a minimal single-stream profile for tests."""
+    return LoadProfileConfig(
+        name="single_stream_light",
+        description="test",
+        concurrency=1,
+        request_count=request_count,
+        input_token_range=(50, 100),
+        output_token_range=(50, 100),
+        cache_strategy="minimal",
+    )
+
+
+def _make_chat_response(prompt_tokens: int = 50, completion_tokens: int = 100) -> bytes:
+    """Build a fake OpenAI-style chat completion JSON response body."""
+    return json.dumps(
+        {
+            "id": "test",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+    ).encode()
+
+
+class _FakeUrlopenResponse:
+    """Context-manager stub matching urllib.request.urlopen()'s interface."""
+
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+@pytest.fixture
+def deterministic_sampler():
+    """Force GpuPowerSampler to return a fixed avg_power_watts.
+
+    Avoids depending on a real nvidia-smi in CI. The threading start/stop
+    behaviour is bypassed entirely so tests don't sleep.
+    """
+    with (
+        patch.object(GpuPowerSampler, "start", lambda self: None),
+        patch.object(GpuPowerSampler, "stop", lambda self: None),
+        patch.object(
+            GpuPowerSampler,
+            "avg_power_watts",
+            new=property(lambda self: 250.0),
+        ),
+    ):
+        yield
+
+
+class TestGpuPowerSampler:
+    """Tests for the standalone GpuPowerSampler."""
+
+    def test_avg_power_with_no_samples_is_zero(self):
+        """An idle sampler reports 0.0 W instead of dividing by zero."""
+        sampler = GpuPowerSampler()
+        assert sampler.avg_power_watts == 0.0
+
+    def test_avg_power_averages_collected_samples(self):
+        sampler = GpuPowerSampler()
+        sampler.samples = [100.0, 200.0, 300.0]
+        assert sampler.avg_power_watts == 200.0
+
+    def test_sample_loop_handles_missing_nvidia_smi(self):
+        """If nvidia-smi isn't on PATH, the loop drops samples silently.
+
+        Regression-style: the sampler is used in mock test environments
+        without an NVIDIA driver; a FileNotFoundError must not crash the
+        background thread.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        with patch("subprocess.run", side_effect=FileNotFoundError("no nvidia-smi")):
+            sampler.start()
+            # Let the loop attempt one iteration, then stop
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples == []
+
+    def test_sample_loop_handles_unparseable_output(self):
+        """Bad output from nvidia-smi is dropped, not propagated."""
+        sampler = GpuPowerSampler(interval_s=0.01)
+        fake_result = MagicMock(returncode=0, stdout="not-a-float\n")
+        with patch("subprocess.run", return_value=fake_result):
+            sampler.start()
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples == []
+
+
+class TestSingleStreamExecutor:
+    """Tests for SingleStreamExecutor's request loop and aggregation."""
+
+    def test_run_populates_energy_from_power_and_duration(self, deterministic_sampler):
+        """energy_joules must equal avg_power_watts * request_duration_seconds.
+
+        This is the core invariant of single-stream attribution.
+        """
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeUrlopenResponse(_make_chat_response(50, 100)),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert result.successful_requests == 1
+        assert result.failed_requests == 0
+        req = result.individual_results[0]
+        assert req.energy_joules is not None
+        # avg_power_watts is forced to 250.0 by the fixture
+        assert req.avg_power_watts == 250.0
+        # Allow some floating-point slop on the duration multiplication
+        assert req.energy_joules == pytest.approx(250.0 * req.request_duration_seconds, rel=1e-9)
+
+    def test_run_forces_concurrency_to_1(self, deterministic_sampler):
+        """Even if a profile claims concurrency=4, single-stream must serialize.
+
+        Per-request power attribution is only valid when requests don't
+        overlap on the GPU; the executor must ignore the profile's
+        concurrency field rather than silently produce invalid data.
+        """
+        profile = LoadProfileConfig(
+            name="lying_profile",
+            description="profile claims concurrency=4 — executor must ignore",
+            concurrency=4,
+            request_count=3,
+            input_token_range=(50, 100),
+            output_token_range=(50, 100),
+            cache_strategy="minimal",
+        )
+        executor = SingleStreamExecutor(seed=42)
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeUrlopenResponse(_make_chat_response()),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert result.concurrency == 1
+        assert result.successful_requests == 3
+
+    def test_run_records_http_error(self, deterministic_sampler):
+        """HTTP failures land as RequestResult.error, not exceptions."""
+        import urllib.error
+
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        http_err = urllib.error.HTTPError(
+            url="http://localhost:8000/v1/chat/completions",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=http_err):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert result.successful_requests == 0
+        assert result.failed_requests == 1
+        assert result.individual_results[0].status_code == 503
+        assert "HTTP 503" in (result.individual_results[0].error or "")
+
+    def test_endpoint_v1_suffix_is_appended_when_missing(self, deterministic_sampler):
+        """Passing 'http://host:8000' must produce requests to '/v1/chat/completions'."""
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        captured_urls = []
+
+        def _capture(req, *args, **kwargs):
+            captured_urls.append(req.full_url)
+            return _FakeUrlopenResponse(_make_chat_response())
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            executor.run(profile, "http://localhost:8000", "test-model")
+
+        assert captured_urls == ["http://localhost:8000/v1/chat/completions"]
+
+    def test_endpoint_with_trailing_slash_is_normalized(self, deterministic_sampler):
+        """'http://host:8000/v1/' must not double up the slashes."""
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        captured_urls = []
+
+        def _capture(req, *args, **kwargs):
+            captured_urls.append(req.full_url)
+            return _FakeUrlopenResponse(_make_chat_response())
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            executor.run(profile, "http://localhost:8000/v1/", "test-model")
+
+        assert captured_urls == ["http://localhost:8000/v1/chat/completions"]
+
+    def test_api_key_adds_bearer_header(self, deterministic_sampler):
+        """When api_key is set, the request must carry an Authorization header."""
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        captured_headers = []
+
+        def _capture(req, *args, **kwargs):
+            captured_headers.append(dict(req.headers))
+            return _FakeUrlopenResponse(_make_chat_response())
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            executor.run(profile, "http://localhost:8000/v1", "test-model", api_key="sk-test")
+
+        # urllib normalizes header names; check case-insensitively
+        merged = {k.lower(): v for k, v in captured_headers[0].items()}
+        assert merged.get("authorization") == "Bearer sk-test"
+
+    def test_aggregate_tokens_per_joule_uses_total_tokens(self, deterministic_sampler):
+        """tokens_per_joule = sum(total_tokens) / sum(energy_joules).
+
+        Energy is consumed for both prefill (input) and decode (output);
+        the aggregate must reflect that.
+        """
+        profile = _make_profile(request_count=2)
+        executor = SingleStreamExecutor(seed=42)
+
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_FakeUrlopenResponse(
+                _make_chat_response(prompt_tokens=30, completion_tokens=70)
+            ),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        # Each request: total_tokens=100, energy = 250 * duration
+        assert result.total_tokens == 200
+        assert result.tokens_per_joule is not None
+        assert result.total_energy_joules is not None
+        assert result.tokens_per_joule == pytest.approx(
+            result.total_tokens / result.total_energy_joules
+        )
+
+
+class TestCliOutputFormat:
+    """Verify the CLI writes the JSONL shape downstream consumers expect."""
+
+    def test_meta_header_has_required_fields(self, tmp_path):
+        """JSONL `_meta` header must contain the fields downstream looks up
+        when computing benchmark_source resolution and provenance.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+
+        args = MagicMock(
+            tensor_parallel=2,
+            serving_engine="vllm",
+            endpoint="http://localhost:8000/v1",
+            power_sample_interval=0.1,
+            gpu_type="H200",
+            quantization=None,
+            max_model_len=32768,
+            gpu_memory_utilization=0.9,
+        )
+        meta = cli.build_meta_header("Qwen/Qwen3-32B", "single_stream_light", args)
+
+        # Downstream's loader needs these to land at the right benchmark_source.
+        assert meta["_meta"] is True
+        assert meta["benchmark_source"] == "codecarbon_sweep"
+        assert meta["measurement_mode"] == "local-power-sampling"
+        assert meta["concurrency"] == 1
+        # The display profile name is the short form (e.g. "light"), not "single_stream_light"
+        assert meta["profile_name"] == "light"
+        assert meta["tensor_parallel"] == 2
+        assert meta["gpu_type"] == "H200"
+        assert meta["max_model_len"] == 32768
+
+    def test_request_row_has_energy_and_token_fields(self):
+        """Per-request JSONL row must carry energy, power, duration,
+        token counts, and the derived metrics downstream's loader uses.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=30,
+            completion_tokens=70,
+            total_tokens=100,
+            request_duration_seconds=0.5,
+            energy_joules=125.0,
+            energy_kwh=125.0 / 3_600_000.0,
+            avg_power_watts=250.0,
+            inference_duration_seconds=0.5,
+            attribution_method="local-power-sampling",
+            attribution_ratio=1.0,
+            status_code=200,
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert row["energy_joules"] == 125.0
+        assert row["avg_power_watts"] == 250.0
+        assert row["duration_seconds"] == 0.5
+        assert row["input_tokens"] == 30
+        assert row["output_tokens"] == 70
+        assert row["thinking_tokens"] == 0
+        # Values in the JSONL row are rounded to 4 decimals for compact output;
+        # use abs tolerance that accommodates that rounding.
+        assert row["tokens_per_joule"] == pytest.approx(100 / 125.0, abs=1e-4)
+        assert row["energy_per_useful_token"] == pytest.approx(125.0 / 70, abs=1e-4)
+
+    def test_request_row_for_failed_request_is_error_only(self):
+        """Failed requests must serialize without bogus zero energy fields
+        that would skew downstream aggregation.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            request_duration_seconds=1.2,
+            error="Connection refused",
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert "error" in row
+        assert row["error"] == "Connection refused"
+        assert "energy_joules" not in row
+        assert "tokens_per_joule" not in row
+
+    def test_write_jsonl_output_layout(self, tmp_path):
+        """File must start with a single meta row, then one row per request."""
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        out = tmp_path / "out.jsonl"
+        meta = {"_meta": True, "model": "test", "benchmark_source": "codecarbon_sweep"}
+        results = [
+            RequestResult(
+                prompt_tokens=10,
+                completion_tokens=20,
+                total_tokens=30,
+                request_duration_seconds=0.1,
+                energy_joules=25.0,
+                avg_power_watts=250.0,
+            )
+        ]
+        cli.write_jsonl_output(out, meta, results)
+        lines = out.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["_meta"] is True
+        assert json.loads(lines[1])["energy_joules"] == 25.0

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -481,6 +481,62 @@ class TestSingleStreamExecutor:
             result.total_tokens / result.total_energy_joules
         )
 
+    def test_aggregate_tokens_per_joule_uses_matched_subset(self):
+        """tokens_per_joule must divide tokens from the SAME requests whose
+        energy is in the denominator. Mixing all-successful-tokens over
+        energy-subset-joules inflates efficiency when some requests lost
+        power data.
+
+        Regression: a glm-5.1-flex review caught that the aggregate summed
+        `total_tokens` over all successful requests but `total_energy_j`
+        over only the subset with energy data, making the metric look
+        better than reality.
+        """
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        executor = SingleStreamExecutor(seed=42)
+
+        # 8 requests with energy data: 10_000 tokens, 2000 J → 5 tok/J
+        # 2 successful requests without energy: 2000 tokens
+        # Buggy formula: 12_000 / 2000 = 6 tok/J  (inflated by 20%)
+        # Correct formula: 10_000 / 2000 = 5 tok/J
+        results: List[RequestResult] = []
+        for _ in range(8):
+            results.append(
+                RequestResult(
+                    prompt_tokens=625,
+                    completion_tokens=625,
+                    total_tokens=1250,
+                    request_duration_seconds=1.0,
+                    energy_joules=250.0,
+                    avg_power_watts=250.0,
+                )
+            )
+        for _ in range(2):
+            results.append(
+                RequestResult(
+                    prompt_tokens=500,
+                    completion_tokens=500,
+                    total_tokens=1000,
+                    request_duration_seconds=1.0,
+                    energy_joules=None,
+                    avg_power_watts=None,
+                )
+            )
+
+        aggregated = executor._aggregate_results(
+            profile_name="test",
+            model="test-model",
+            endpoint="http://localhost:8000/v1",
+            results=results,
+            wall_clock_seconds=10.0,
+        )
+        # 8 energy requests × 250 J = 2000 J. 8 energy requests × 1250 tok = 10_000 tok.
+        assert aggregated.total_energy_joules == pytest.approx(2000.0)
+        assert aggregated.tokens_per_joule == pytest.approx(5.0)
+        # total_tokens still spans all 10 successful requests
+        assert aggregated.total_tokens == 12_000
+
 
 class TestCliOutputFormat:
     """Verify the CLI writes the JSONL shape downstream consumers expect."""

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -143,6 +143,46 @@ class TestGpuPowerSampler:
         assert sampler.samples == []
         assert sampler.sample_errors > 0
 
+    def test_sample_loop_sums_across_multiple_gpus(self):
+        """nvidia-smi emits one line per GPU; the sampler must sum them.
+
+        Regression: previously the loop took only `split("\n")[0]` and
+        silently undercounted energy on `--tensor-parallel N` runs by
+        a factor of ~N. The CLI accepts `--tensor-parallel` without any
+        warning, so a TP=4 H100 run would have looked like a TP=1 run
+        at 1/4 the real power draw.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        # Simulate a 4-GPU node — nvidia-smi prints one line per GPU.
+        fake_result = MagicMock(returncode=0, stdout="120.5\n118.0\n121.3\n119.2\n")
+        with patch("subprocess.run", return_value=fake_result):
+            sampler.start()
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples, "expected at least one sample"
+        # Each sample must equal the sum of all 4 GPU readings.
+        expected = 120.5 + 118.0 + 121.3 + 119.2
+        for s in sampler.samples:
+            assert s == pytest.approx(expected, rel=1e-9)
+
+    def test_sample_loop_treats_empty_stdout_as_error(self):
+        """If nvidia-smi exits 0 but emits no lines (rare), we count it as
+        a sample error instead of recording 0 W. Recording 0 W would drag
+        the per-request average down and mask a measurement failure.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        fake_result = MagicMock(returncode=0, stdout="\n")
+        with patch("subprocess.run", return_value=fake_result):
+            sampler.start()
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples == []
+        assert sampler.sample_errors > 0
+
     def test_start_resets_sample_errors(self):
         """A re-used sampler must reset the error count between runs.
 
@@ -421,9 +461,9 @@ class TestSingleStreamExecutor:
         ):
             executor.run(profile, "http://localhost:8000/v1", "test-model")
 
-        assert any(
-            "sample-error rate" in r.message for r in caplog.records
-        ), f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
+        assert any("sample-error rate" in r.message for r in caplog.records), (
+            f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
+        )
 
     def test_executor_does_not_warn_when_sample_error_rate_low(self, caplog):
         """Quiet runs must stay quiet — no warning for a small handful of

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -143,6 +143,27 @@ class TestGpuPowerSampler:
         assert sampler.samples == []
         assert sampler.sample_errors > 0
 
+    def test_sample_loop_handles_permission_error(self):
+        """nvidia-smi present but not executable must not kill the sampler.
+
+        Regression: previously the loop caught only FileNotFoundError, so
+        PermissionError (a different OSError subclass — e.g. restrictive
+        container seccomp or a bind-mounted binary without +x) would
+        escape the handler and terminate the background sampler thread
+        with an unhandled exception. The request would then report
+        energy_joules=None with sample_errors still at 0 — no audit
+        trail that anything went wrong.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        with patch("subprocess.run", side_effect=PermissionError("no exec")):
+            sampler.start()
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples == []
+        assert sampler.sample_errors > 0
+
     def test_sample_loop_sums_across_multiple_gpus(self):
         """nvidia-smi emits one line per GPU; the sampler must sum them.
 

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -124,6 +124,41 @@ class TestGpuPowerSampler:
             sampler.stop()
         assert sampler.samples == []
 
+    def test_sample_loop_counts_errors(self):
+        """Failed nvidia-smi calls must increment sample_errors so callers
+        can audit measurement quality. Without this counter a silent timeout
+        just shrinks the sample list and disappears.
+
+        Regression: a kimi reviewer flagged that the old loop swallowed
+        TimeoutExpired with no signal at all, leaving downstream unable to
+        tell a clean run apart from one where most readings were lost.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        with patch("subprocess.run", side_effect=FileNotFoundError("no nvidia-smi")):
+            sampler.start()
+            import time
+
+            time.sleep(0.05)
+            sampler.stop()
+        assert sampler.samples == []
+        assert sampler.sample_errors > 0
+
+    def test_start_resets_sample_errors(self):
+        """A re-used sampler must reset the error count between runs.
+
+        Without this the count would grow unboundedly across requests when
+        a sampler is incidentally reused.
+        """
+        sampler = GpuPowerSampler(interval_s=0.01)
+        sampler.sample_errors = 42  # leftover from a prior run
+        with patch("subprocess.run", side_effect=FileNotFoundError("no nvidia-smi")):
+            sampler.start()
+            sampler.stop()
+        # Sample_errors was reset to 0 in start() and then incremented by the
+        # missing-binary path. The reset is the assertion of interest; the
+        # exact end value depends on loop timing, so check the reset happened.
+        assert sampler.sample_errors < 42
+
 
 class TestSingleStreamExecutor:
     """Tests for SingleStreamExecutor's request loop and aggregation."""
@@ -328,6 +363,99 @@ class TestSingleStreamExecutor:
         assert len(constructed) == 3
         assert len({id(s) for s in constructed}) == 3
 
+    def test_executor_propagates_sample_errors_into_request_result(self):
+        """The RequestResult must carry the sampler's error count so the
+        JSONL row downstream can audit measurement quality.
+        """
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        def _start_with_errors(self):
+            self.samples = [250.0]
+            self.sample_errors = 7
+
+        with (
+            patch.object(GpuPowerSampler, "start", _start_with_errors),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch.object(
+                GpuPowerSampler,
+                "avg_power_watts",
+                new=property(lambda self: 250.0),
+            ),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(_make_chat_response()),
+            ),
+        ):
+            result = executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        req = result.individual_results[0]
+        assert req.sample_errors == 7
+
+    def test_executor_warns_when_sample_error_rate_high(self, caplog):
+        """A request where >25% of nvidia-smi calls failed must emit a warning
+        so the operator notices the energy figure isn't trustworthy.
+        """
+        import logging
+
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        def _start_with_high_error_rate(self):
+            self.samples = [250.0, 250.0]  # 2 good
+            self.sample_errors = 8  # 8 failed → 80% error rate
+
+        with (
+            patch.object(GpuPowerSampler, "start", _start_with_high_error_rate),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch.object(
+                GpuPowerSampler,
+                "avg_power_watts",
+                new=property(lambda self: 250.0),
+            ),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(_make_chat_response()),
+            ),
+            caplog.at_level(logging.WARNING, logger="ai_energy_benchmarks.executors.single_stream"),
+        ):
+            executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert any("sample-error rate" in r.message for r in caplog.records), (
+            f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_executor_does_not_warn_when_sample_error_rate_low(self, caplog):
+        """Quiet runs must stay quiet — no warning for a small handful of
+        sample errors below the 25% threshold.
+        """
+        import logging
+
+        profile = _make_profile(request_count=1)
+        executor = SingleStreamExecutor(seed=42)
+
+        def _start_with_low_error_rate(self):
+            self.samples = [250.0] * 20  # 20 good
+            self.sample_errors = 1  # 1 failed → ~5% error rate
+
+        with (
+            patch.object(GpuPowerSampler, "start", _start_with_low_error_rate),
+            patch.object(GpuPowerSampler, "stop", lambda self: None),
+            patch.object(
+                GpuPowerSampler,
+                "avg_power_watts",
+                new=property(lambda self: 250.0),
+            ),
+            patch(
+                "urllib.request.urlopen",
+                return_value=_FakeUrlopenResponse(_make_chat_response()),
+            ),
+            caplog.at_level(logging.WARNING, logger="ai_energy_benchmarks.executors.single_stream"),
+        ):
+            executor.run(profile, "http://localhost:8000/v1", "test-model")
+
+        assert not any("sample-error rate" in r.message for r in caplog.records)
+
     def test_aggregate_tokens_per_joule_uses_total_tokens(self, deterministic_sampler):
         """tokens_per_joule = sum(total_tokens) / sum(energy_joules).
 
@@ -473,6 +601,65 @@ class TestCliOutputFormat:
         assert "energy_joules" not in row
         assert "tokens_per_joule" not in row
 
+    def test_request_row_includes_sample_errors_when_present(self):
+        """JSONL row must surface the sampler's error count so operators
+        and downstream code can audit measurement quality. Regression:
+        previously discarded with no way to spot a degraded measurement.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=30,
+            completion_tokens=70,
+            total_tokens=100,
+            request_duration_seconds=0.5,
+            energy_joules=125.0,
+            avg_power_watts=250.0,
+            sample_errors=3,
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert row["sample_errors"] == 3
+
+    def test_request_row_omits_sample_errors_when_none(self):
+        """When the executor didn't track sample_errors (e.g. an older row)
+        the field must be omitted rather than emit a misleading 'null'.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=30,
+            completion_tokens=70,
+            total_tokens=100,
+            request_duration_seconds=0.5,
+            energy_joules=125.0,
+            avg_power_watts=250.0,
+            sample_errors=None,
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert "sample_errors" not in row
+
+    def test_request_row_for_failed_request_carries_sample_errors(self):
+        """Even error rows benefit from the sample_errors count — it helps
+        distinguish "request failed because nvidia-smi was broken" from
+        "request failed for unrelated reasons."
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import RequestResult
+
+        req = RequestResult(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            request_duration_seconds=1.2,
+            error="Connection refused",
+            sample_errors=4,
+        )
+        row = cli.request_result_to_jsonl_row(req)
+        assert row["error"] == "Connection refused"
+        assert row["sample_errors"] == 4
+
     def test_write_jsonl_output_layout(self, tmp_path):
         """File must start with a single meta row, then one row per request."""
         from ai_energy_benchmarks.cli import single_stream as cli
@@ -495,3 +682,74 @@ class TestCliOutputFormat:
         assert len(lines) == 2
         assert json.loads(lines[0])["_meta"] is True
         assert json.loads(lines[1])["energy_joules"] == 25.0
+
+
+class TestCliExitCode:
+    """The CLI must exit non-zero whenever any request failed.
+
+    Regression: the previous check `successful_requests > 0` treated 19/20
+    failures as a successful run, which let CI/orchestrators silently merge
+    bad data. A partial failure must surface as a non-zero exit code.
+    """
+
+    def _run_main_with_result(self, monkeypatch, tmp_path, successful: int, failed: int):
+        """Drive cli.main() with a stubbed-out executor that yields the
+        requested success/fail counts, and return the SystemExit code.
+        """
+        from ai_energy_benchmarks.cli import single_stream as cli
+        from ai_energy_benchmarks.executors.energy_aware import ProfileResult
+
+        sys_argv = [
+            "ai-energy-single-stream",
+            "--model",
+            "test-model",
+            "--output-dir",
+            str(tmp_path),
+        ]
+        monkeypatch.setattr("sys.argv", sys_argv)
+
+        from datetime import datetime, timezone
+
+        fake_result = ProfileResult(
+            profile_name="single_stream_light",
+            model="test-model",
+            endpoint="http://localhost:8000/v1",
+            timestamp=datetime.now(timezone.utc),
+            request_count=successful + failed,
+            successful_requests=successful,
+            failed_requests=failed,
+            concurrency=1,
+            total_tokens=0,
+            total_prompt_tokens=0,
+            total_completion_tokens=0,
+            total_wall_clock_seconds=1.0,
+            total_inference_seconds=1.0,
+            tokens_per_second=0.0,
+            individual_results=[],
+        )
+
+        class _FakeExecutor:
+            def __init__(self, *a, **k):
+                pass
+
+            def run(self, *a, **k):
+                return fake_result
+
+        monkeypatch.setattr(cli, "SingleStreamExecutor", _FakeExecutor)
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli.main()
+        return excinfo.value.code
+
+    def test_exit_zero_when_all_requests_succeed(self, monkeypatch, tmp_path):
+        code = self._run_main_with_result(monkeypatch, tmp_path, successful=10, failed=0)
+        assert code == 0
+
+    def test_exit_nonzero_on_partial_failure(self, monkeypatch, tmp_path):
+        """One success out of twenty is NOT a passing run — exit non-zero."""
+        code = self._run_main_with_result(monkeypatch, tmp_path, successful=1, failed=19)
+        assert code != 0
+
+    def test_exit_nonzero_when_no_requests_succeed(self, monkeypatch, tmp_path):
+        code = self._run_main_with_result(monkeypatch, tmp_path, successful=0, failed=10)
+        assert code != 0

--- a/tests/unit/test_single_stream_executor.py
+++ b/tests/unit/test_single_stream_executor.py
@@ -421,9 +421,9 @@ class TestSingleStreamExecutor:
         ):
             executor.run(profile, "http://localhost:8000/v1", "test-model")
 
-        assert any("sample-error rate" in r.message for r in caplog.records), (
-            f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
-        )
+        assert any(
+            "sample-error rate" in r.message for r in caplog.records
+        ), f"expected sample-error warning, got: {[r.message for r in caplog.records]}"
 
     def test_executor_does_not_warn_when_sample_error_rate_low(self, caplog):
         """Quiet runs must stay quiet — no warning for a small handful of


### PR DESCRIPTION
## Summary

Adds an on-box equivalent of `EnergyAwareExecutor` that samples GPU power locally via `nvidia-smi` while a request is in flight, instead of reading per-request energy from a gateway response. Useful for benchmarking raw vLLM (or any OpenAI-compatible endpoint that does not expose per-request energy).

Per-request energy is computed as `avg_power_watts * request_duration_seconds`. This attribution is only valid at concurrency=1, so the executor forces the profile concurrency to 1 and serializes requests.

## What is added

- `ai_energy_benchmarks/executors/single_stream.py` — `GpuPowerSampler` (background nvidia-smi sampler) + `SingleStreamExecutor`
- `ai_energy_benchmarks/cli/single_stream.py` — `ai-energy-single-stream` CLI entry, writes JSONL with a `_meta` header + one row per request
- 15 new unit tests in `tests/unit/test_single_stream_executor.py`
- Reuses existing `LoadProfileConfig` and the `single_stream_*` profile family (added in PR #33)

## Motivation

Downstream (`energy-aware-inference`) had a ~530-line standalone `sweep_codecarbon.py` that re-implemented power sampling, prompt generation, and JSONL writing. That measurement logic belongs here — the design doc soft-requires the dashboard pipeline to use `ai_energy_benchmarks` under the hood. With this CLI in place, downstream becomes a thin orchestrator (companion PR will follow).

## Test plan
- [x] `pytest tests/unit/test_single_stream_executor.py` — 15 tests pass
- [x] Full suite still passes (178 tests)
- [x] `ruff check` clean
- [ ] End-to-end on a real GPU box against vLLM serving Qwen3.5-0.8B with `single_stream_light`; verify JSONL shape loads through the downstream loader (to be done before un-drafting)

## Notes

Marked draft until the e2e on real hardware confirms the produced JSONL loads correctly through the downstream loader.

Generated with Claude Code
